### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,14 @@ idCreator是我们设计并且开发一个分布式的id生成器。它主要为
 5. 进入config文件夹，根据你实际的情况配置id生成器信息  
 5. 执行./idCreator config/idcreator.config 即可运行  
 
-#idCreator 限制  
+# idCreator 限制  
 1. 目前每台机器一秒大概可以生成10k的id  
 2. 目前id生成器的机器总数被限定在10台，mid从0--9  
 3. 目前id生成器被设计成明确生成类型的最大值为100，也就是为100种数据生成id  
 4. 分库的位被设计成空余了2位，也就是说最多支持一个业务被拆分成100个数据库，从0-99  
 5. 目前，id生成器只支持linux运行  
 
-#idCreator客户端  
+# idCreator客户端  
 1. C，本身idCreator就是c写的，所以它有c的客户端没有什么意外  
 2. java，但是目前该客户端需要和albianj一起被使用  
 3. http，屏蔽各种语言，idCreator支持通过http访问，其内置有web服务器,
@@ -39,7 +39,7 @@ json的响应：{error:0, errorMessage:success, result:4159860000002400},其中r
 
 详细文档请查看[wiki](https://github.com/crosg/idCreator/wiki)  
 
-#idCreator 文档列表和qq群:  
+# idCreator 文档列表和qq群:  
 [idCreator的设计思路文档] (http://www.94geek.com/2015/idcreator.html "idCreator设计思路文档")  
 qq群：528658887  
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
